### PR TITLE
Add "Open in Codeanywhere" button in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 Clone this repo or [open in Gitpod](https://gitpod.io/#https://github.com/total-typescript/advanced-patterns-workshop).
 
+Or get this project running instantly with **Codeanywhere** by clicking the button below:  
+
+[![Open in Codeanywhere](https://codeanywhere.com/img/open-in-codeanywhere-btn.svg)](https://app.codeanywhere.com/#https://github.com/total-typescript/advanced-patterns-workshop)
+
 ```sh
 # Installs all dependencies
 npm install


### PR DESCRIPTION
Codeanywhere is a cloud-based development environment that allows developers to open the repo and code in the browser-bassed IDE. It supports a wide range of programming languages, enabling users to work directly within their browser without needing a local setup. With its flexibility and Github integration, it streamlines remote development workflows for individuals and teams.

This PR is adding "Open in Codeanywhere" button to the Readme file. Clicking the button opens the repo in Codeanywhere IDE with a dedicated workspace container running and allows users to start coding in minutes.

This is the same functionality as opening in Gitpod that is already in the Readme, but with Codeanywhere, which is the same type of platform.