### PR TITLE
another 14 solution

### DIFF
--- a/src/03-type-predicates-assertion-functions/14-typescripts-worst-error.solution.ts
+++ b/src/03-type-predicates-assertion-functions/14-typescripts-worst-error.solution.ts
@@ -15,13 +15,23 @@ interface NormalUser extends User {
   role: "normal";
 }
 
-function assertUserIsAdmin(
+const assertUserIsAdmin: (
   user: NormalUser | AdminUser,
-): asserts user is AdminUser {
+) => asserts user is AdminUser = (
+  user: NormalUser | AdminUser,
+): asserts user is AdminUser => {
   if (user.role !== "admin") {
     throw new Error("Not an admin user");
   }
-}
+};
+
+// function assertUserIsAdmin(
+//   user: NormalUser | AdminUser,
+// ): asserts user is AdminUser {
+//   if (user.role !== "admin") {
+//     throw new Error("Not an admin user");
+//   }
+// }
 
 it("Should throw an error when it encounters a normal user", () => {
   const user: NormalUser = {
@@ -37,7 +47,8 @@ it("Should assert that the type is an admin user after it has been validated", (
   const example = (user: NormalUser | AdminUser) => {
     /**
      * The fix is to make assertUserIsAdmin a function,
-     * not an arrow function. Lord above.
+     * or to add the explicit type annotation back to the arrow function
+     * Lord above.
      */
     assertUserIsAdmin(user);
 


### PR DESCRIPTION
Add an explicit type annotation to the arrow function in `assertUserIsAdmin`.

Yes, it’s a bit redundant and looks ugly, but TypeScript insists on its daily sacrifice 😅  
After this, TypeScript will finally recognize the type as `AdminUser` without complaining.
